### PR TITLE
feat: add GSD calculation endpoint

### DIFF
--- a/server/routes/gsd.js
+++ b/server/routes/gsd.js
@@ -1,23 +1,48 @@
 import { Router } from 'express';
-import { calculateGSD } from '../utils/calculations.js';
-import { droneModels } from '../config/droneModels.js';
+import { calculateGsdMetrics } from '../utils/gsdCalculator.js';
 
 const router = Router();
 
 router.get('/', (req, res) => {
-  const { model, altitude } = req.query;
-  const drone = droneModels.find((d) => d.model === model);
-  if (!drone) {
-    return res.status(400).json({ error: 'Unknown model' });
-  }
   try {
-    const gsd = calculateGSD({
-      sensorWidth: drone.sensorWidth,
-      imageWidth: drone.imageWidth,
-      altitude: Number(altitude || 0),
-      focalLength: drone.focalLength,
-    });
-    res.json({ gsd });
+    const {
+      sensorWidth,
+      focalLength,
+      imageWidth,
+      imageHeight,
+      flightAltitude,
+      roofHeight,
+      frontOverlap,
+      sideOverlap,
+      units,
+    } = req.query;
+
+    const params = {
+      sensorWidth: parseFloat(sensorWidth),
+      focalLength: parseFloat(focalLength),
+      imageWidth: parseFloat(imageWidth),
+      imageHeight: parseFloat(imageHeight),
+      flightAltitude: parseFloat(flightAltitude),
+      roofHeight: roofHeight ? parseFloat(roofHeight) : 0,
+      frontOverlap: frontOverlap ? parseFloat(frontOverlap) : 0.8,
+      sideOverlap: sideOverlap ? parseFloat(sideOverlap) : 0.8,
+      units: units && units.toLowerCase() === 'imperial' ? 'imperial' : 'metric',
+    };
+
+    const required = [
+      params.sensorWidth,
+      params.focalLength,
+      params.imageWidth,
+      params.imageHeight,
+      params.flightAltitude,
+    ];
+
+    if (required.some((v) => isNaN(v) || v <= 0)) {
+      return res.status(400).json({ error: 'Missing or invalid parameters' });
+    }
+
+    const result = calculateGsdMetrics(params);
+    res.json({ ...result, units: params.units });
   } catch (err) {
     res.status(400).json({ error: err.message });
   }

--- a/server/utils/gsdCalculator.js
+++ b/server/utils/gsdCalculator.js
@@ -1,0 +1,82 @@
+export function calculateGsdMetrics({
+  sensorWidth,
+  focalLength,
+  imageWidth,
+  imageHeight,
+  flightAltitude,
+  roofHeight = 0,
+  frontOverlap = 0.8,
+  sideOverlap = 0.8,
+  units = 'metric'
+}) {
+  const required = [sensorWidth, focalLength, imageWidth, imageHeight, flightAltitude];
+  if (required.some((v) => typeof v !== 'number' || isNaN(v) || v <= 0)) {
+    throw new Error('Missing or invalid parameters');
+  }
+
+  const isImperial = units === 'imperial';
+  const toMeters = (v) => (isImperial ? v * 0.3048 : v);
+  const altitudeMeters = toMeters(flightAltitude);
+  const roofMeters = roofHeight > 0 ? toMeters(roofHeight) : 0;
+
+  const groundGsdCm =
+    (sensorWidth * altitudeMeters * 100) / (focalLength * imageWidth);
+
+  let roofGsdCm = groundGsdCm;
+  let effectiveFront = frontOverlap;
+  let effectiveSide = sideOverlap;
+  if (roofMeters > 0 && roofMeters < altitudeMeters) {
+    const adjustedAltitude = altitudeMeters - roofMeters;
+    roofGsdCm =
+      (sensorWidth * adjustedAltitude * 100) / (focalLength * imageWidth);
+    const scale = altitudeMeters / adjustedAltitude;
+    effectiveFront = 1 - (1 - frontOverlap) * scale;
+    effectiveSide = 1 - (1 - sideOverlap) * scale;
+  }
+
+  const footprintWidthMeters = (groundGsdCm * imageWidth) / 100;
+  const footprintHeightMeters = (groundGsdCm * imageHeight) / 100;
+
+  const convertLength = (v) => (isImperial ? v * 3.28084 : v);
+  const convertGsd = (v) => (isImperial ? v / 2.54 : v);
+
+  return {
+    groundGSD: parseFloat(convertGsd(groundGsdCm).toFixed(3)),
+    roofGSD: parseFloat(convertGsd(roofGsdCm).toFixed(3)),
+    footprintWidth: parseFloat(convertLength(footprintWidthMeters).toFixed(3)),
+    footprintHeight: parseFloat(convertLength(footprintHeightMeters).toFixed(3)),
+    effectiveFrontOverlap: parseFloat(effectiveFront.toFixed(4)),
+    effectiveSideOverlap: parseFloat(effectiveSide.toFixed(4)),
+    gsdUnit: isImperial ? 'in/pixel' : 'cm/pixel',
+    footprintUnit: isImperial ? 'feet' : 'meters'
+  };
+}
+
+/*
+Example usage:
+
+// Metric example
+console.log(
+  calculateGsdMetrics({
+    sensorWidth: 13.2,
+    focalLength: 8.8,
+    imageWidth: 4000,
+    imageHeight: 3000,
+    flightAltitude: 100,
+    roofHeight: 20,
+  })
+);
+
+// Imperial example (inputs in feet)
+console.log(
+  calculateGsdMetrics({
+    sensorWidth: 13.2,
+    focalLength: 8.8,
+    imageWidth: 4000,
+    imageHeight: 3000,
+    flightAltitude: 328.084, // 100 m in feet
+    roofHeight: 65.617, // 20 m in feet
+    units: 'imperial'
+  })
+);
+*/

--- a/server/utils/gsdExamples.js
+++ b/server/utils/gsdExamples.js
@@ -1,0 +1,27 @@
+import { calculateGsdMetrics } from './gsdCalculator.js';
+
+// Common parameters for a hypothetical camera
+const common = {
+  sensorWidth: 13.2,
+  focalLength: 8.8,
+  imageWidth: 4000,
+  imageHeight: 3000,
+  flightAltitude: 100,
+  frontOverlap: 0.8,
+  sideOverlap: 0.8,
+};
+
+console.log('Metric no roof:', calculateGsdMetrics(common));
+console.log(
+  'Metric roof 20m:',
+  calculateGsdMetrics({ ...common, roofHeight: 20 })
+);
+console.log(
+  'Imperial roof 65.6ft:',
+  calculateGsdMetrics({
+    ...common,
+    flightAltitude: 328.084, // 100 m in feet
+    roofHeight: 65.617, // 20 m in feet
+    units: 'imperial',
+  })
+);


### PR DESCRIPTION
## Summary
- calculate ground/roof GSD, footprint size and overlap adjustments with metric and imperial support
- expose new `/api/gsd` route that validates params and returns GSD metrics as JSON
- add example script demonstrating metric vs imperial results and roof overlap reduction

## Testing
- `node server/utils/gsdExamples.js`
- `npm test --prefix server` *(fails: Missing script "test")*
- `npm run lint --prefix server` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab112155fc832c857d043a72f596e4