### PR TITLE
feat: add roof overlap adjustment

### DIFF
--- a/client/src/pages/Calculator.jsx
+++ b/client/src/pages/Calculator.jsx
@@ -1,16 +1,41 @@
 import React, { useState } from 'react';
 import { fetchGSD } from '../utils/api';
 
+const DRONE_MODELS = {
+  'DJI Phantom 4 Pro': {
+    sensorWidth: 13.2,
+    imageWidth: 5472,
+    imageHeight: 3648,
+    focalLength: 8.8,
+  },
+  'DJI Mavic 3': {
+    sensorWidth: 17.3,
+    imageWidth: 5280,
+    imageHeight: 3956,
+    focalLength: 24,
+  },
+};
+
 export default function Calculator() {
   const [model, setModel] = useState('DJI Phantom 4 Pro');
   const [altitude, setAltitude] = useState(100);
-  const [gsd, setGSD] = useState(null);
+  const [roofHeight, setRoofHeight] = useState(0);
+  const [units, setUnits] = useState('metric');
+  const [result, setResult] = useState(null);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const data = await fetchGSD({ model, altitude });
-    setGSD(data.gsd);
+    const params = {
+      ...DRONE_MODELS[model],
+      flightAltitude: parseFloat(altitude),
+      roofHeight: parseFloat(roofHeight),
+      units,
+    };
+    const data = await fetchGSD(params);
+    setResult(data);
   };
+
+  const unitLabel = units === 'imperial' ? 'ft' : 'm';
 
   return (
     <div className="p-4">
@@ -22,12 +47,13 @@ export default function Calculator() {
             onChange={(e) => setModel(e.target.value)}
             className="w-full p-2 border rounded dark:bg-gray-700"
           >
-            <option>DJI Phantom 4 Pro</option>
-            <option>DJI Mavic 3</option>
+            {Object.keys(DRONE_MODELS).map((m) => (
+              <option key={m}>{m}</option>
+            ))}
           </select>
         </div>
         <div>
-          <label className="block mb-1">Altitude (m)</label>
+          <label className="block mb-1">Flight Altitude ({unitLabel})</label>
           <input
             type="number"
             value={altitude}
@@ -35,9 +61,66 @@ export default function Calculator() {
             className="w-full p-2 border rounded dark:bg-gray-700"
           />
         </div>
+        <div>
+          <label className="block mb-1">Roof Height ({unitLabel})</label>
+          <input
+            type="number"
+            value={roofHeight}
+            onChange={(e) => setRoofHeight(e.target.value)}
+            className="w-full p-2 border rounded dark:bg-gray-700"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Units</label>
+          <select
+            value={units}
+            onChange={(e) => setUnits(e.target.value)}
+            className="w-full p-2 border rounded dark:bg-gray-700"
+          >
+            <option value="metric">Metric</option>
+            <option value="imperial">Imperial</option>
+          </select>
+        </div>
         <button className="px-4 py-2 bg-primary text-white rounded">Calculate</button>
       </form>
-      {gsd && <p className="mt-4">GSD: {gsd.toFixed(2)} cm/pixel</p>}
+      {result && (
+        <div className="mt-4 space-y-2">
+          <p>
+            Ground GSD: {result.groundGSD} {result.gsdUnit}
+          </p>
+          <p>
+            Roof GSD: {result.roofGSD} {result.gsdUnit}
+          </p>
+          <p>
+            Effective Front Overlap:{' '}
+            {(result.effectiveFrontOverlap * 100).toFixed(1)}%
+          </p>
+          <p>
+            Effective Side Overlap:{' '}
+            {(result.effectiveSideOverlap * 100).toFixed(1)}%
+          </p>
+          {result.frontOverlapLossPercent > 0 && (
+            <p>Front Overlap Loss: {result.frontOverlapLossPercent.toFixed(1)}%</p>
+          )}
+          {result.sideOverlapLossPercent > 0 && (
+            <p>Side Overlap Loss: {result.sideOverlapLossPercent.toFixed(1)}%</p>
+          )}
+          {result.recommendedAltitude && (
+            <p>
+              Recommended Altitude: {result.recommendedAltitude.toFixed(2)} {unitLabel}
+            </p>
+          )}
+          <p>
+            Recommended Front Overlap:{' '}
+            {(result.recommendedFrontOverlap * 100).toFixed(1)}%
+          </p>
+          <p>
+            Recommended Side Overlap:{' '}
+            {(result.recommendedSideOverlap * 100).toFixed(1)}%
+          </p>
+          {result.warning && <p className="text-red-600">{result.warning}</p>}
+        </div>
+      )}
     </div>
   );
 }

--- a/server/config/settings.js
+++ b/server/config/settings.js
@@ -1,0 +1,4 @@
+export const overlapThresholds = {
+  front: 0.8,
+  side: 0.8,
+};

--- a/server/routes/gsd.js
+++ b/server/routes/gsd.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { calculateGsdMetrics } from '../utils/gsdCalculator.js';
+import { overlapThresholds } from '../config/settings.js';
 
 const router = Router();
 
@@ -41,7 +42,13 @@ router.get('/', (req, res) => {
       return res.status(400).json({ error: 'Missing or invalid parameters' });
     }
 
-    const result = calculateGsdMetrics(params);
+    if (params.roofHeight >= params.flightAltitude) {
+      return res
+        .status(400)
+        .json({ error: 'Roof height must be less than flight altitude' });
+    }
+
+    const result = calculateGsdMetrics({ ...params, thresholds: overlapThresholds });
     res.json({ ...result, units: params.units });
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/server/utils/gsdCalculator.js
+++ b/server/utils/gsdCalculator.js
@@ -7,7 +7,8 @@ export function calculateGsdMetrics({
   roofHeight = 0,
   frontOverlap = 0.8,
   sideOverlap = 0.8,
-  units = 'metric'
+  units = 'metric',
+  thresholds = { front: 0.8, side: 0.8 },
 }) {
   const required = [sensorWidth, focalLength, imageWidth, imageHeight, flightAltitude];
   if (required.some((v) => typeof v !== 'number' || isNaN(v) || v <= 0)) {
@@ -25,14 +26,36 @@ export function calculateGsdMetrics({
   let roofGsdCm = groundGsdCm;
   let effectiveFront = frontOverlap;
   let effectiveSide = sideOverlap;
+  let scale = 1;
   if (roofMeters > 0 && roofMeters < altitudeMeters) {
     const adjustedAltitude = altitudeMeters - roofMeters;
     roofGsdCm =
       (sensorWidth * adjustedAltitude * 100) / (focalLength * imageWidth);
-    const scale = altitudeMeters / adjustedAltitude;
+    scale = altitudeMeters / adjustedAltitude;
     effectiveFront = 1 - (1 - frontOverlap) * scale;
     effectiveSide = 1 - (1 - sideOverlap) * scale;
   }
+
+  const frontLoss = frontOverlap > 0 ? frontOverlap - effectiveFront : 0;
+  const sideLoss = sideOverlap > 0 ? sideOverlap - effectiveSide : 0;
+  const frontLossPercent = frontOverlap > 0 ? (frontLoss / frontOverlap) * 100 : 0;
+  const sideLossPercent = sideOverlap > 0 ? (sideLoss / sideOverlap) * 100 : 0;
+
+  const reqAltitude = (overlap, threshold) => {
+    if (roofMeters <= 0) return 0;
+    const s = (1 - threshold) / (1 - overlap);
+    if (s <= 1) return Infinity;
+    return (s * roofMeters) / (s - 1);
+  };
+
+  const altitudeForFront = reqAltitude(frontOverlap, thresholds.front);
+  const altitudeForSide = reqAltitude(sideOverlap, thresholds.side);
+  const recommendedAltitudeMeters = Math.max(altitudeForFront, altitudeForSide);
+
+  const recommendedFrontOverlap =
+    1 - (1 - thresholds.front) / scale;
+  const recommendedSideOverlap =
+    1 - (1 - thresholds.side) / scale;
 
   const footprintWidthMeters = (groundGsdCm * imageWidth) / 100;
   const footprintHeightMeters = (groundGsdCm * imageHeight) / 100;
@@ -40,16 +63,35 @@ export function calculateGsdMetrics({
   const convertLength = (v) => (isImperial ? v * 3.28084 : v);
   const convertGsd = (v) => (isImperial ? v / 2.54 : v);
 
-  return {
+  const result = {
     groundGSD: parseFloat(convertGsd(groundGsdCm).toFixed(3)),
     roofGSD: parseFloat(convertGsd(roofGsdCm).toFixed(3)),
     footprintWidth: parseFloat(convertLength(footprintWidthMeters).toFixed(3)),
     footprintHeight: parseFloat(convertLength(footprintHeightMeters).toFixed(3)),
     effectiveFrontOverlap: parseFloat(effectiveFront.toFixed(4)),
     effectiveSideOverlap: parseFloat(effectiveSide.toFixed(4)),
+    frontOverlapLossPercent: parseFloat(frontLossPercent.toFixed(2)),
+    sideOverlapLossPercent: parseFloat(sideLossPercent.toFixed(2)),
     gsdUnit: isImperial ? 'in/pixel' : 'cm/pixel',
-    footprintUnit: isImperial ? 'feet' : 'meters'
+    footprintUnit: isImperial ? 'feet' : 'meters',
+    recommendedFrontOverlap: parseFloat(recommendedFrontOverlap.toFixed(4)),
+    recommendedSideOverlap: parseFloat(recommendedSideOverlap.toFixed(4)),
   };
+
+  if (recommendedAltitudeMeters > altitudeMeters && recommendedAltitudeMeters !== Infinity) {
+    result.recommendedAltitude = parseFloat(
+      convertLength(recommendedAltitudeMeters).toFixed(3)
+    );
+  }
+
+  if (
+    effectiveFront < thresholds.front ||
+    effectiveSide < thresholds.side
+  ) {
+    result.warning = 'Overlap below threshold - consider increasing altitude or overlaps.';
+  }
+
+  return result;
 }
 
 /*


### PR DESCRIPTION
## Summary
- add configurable overlap thresholds
- compute roof-level GSD, overlap loss, and recommendations
- surface warnings and suggestions in API and UI

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration because dependencies couldn't be installed)*


------
https://chatgpt.com/codex/tasks/task_e_68ab17defe1c832ca5ff8ce7c2edc872