### PR TITLE
feat: add overlap recommendations

### DIFF
--- a/server/routes/gsd.js
+++ b/server/routes/gsd.js
@@ -1,6 +1,9 @@
 import { Router } from 'express';
-import { calculateGsdMetrics } from '../utils/gsdCalculator.js';
-import { overlapThresholds } from '../config/settings.js';
+import {
+  calculateGSD,
+  computeActualOverlap,
+  recommendFixes,
+} from '../utils/calculations.js';
 
 const router = Router();
 
@@ -12,10 +15,9 @@ router.get('/', (req, res) => {
       imageWidth,
       imageHeight,
       flightAltitude,
-      roofHeight,
-      frontOverlap,
-      sideOverlap,
+      roofHeight = 0,
       units,
+      desiredOverlap = {},
     } = req.query;
 
     const params = {
@@ -25,10 +27,15 @@ router.get('/', (req, res) => {
       imageHeight: parseFloat(imageHeight),
       flightAltitude: parseFloat(flightAltitude),
       roofHeight: roofHeight ? parseFloat(roofHeight) : 0,
-      frontOverlap: frontOverlap ? parseFloat(frontOverlap) : 0.8,
-      sideOverlap: sideOverlap ? parseFloat(sideOverlap) : 0.8,
       units: units && units.toLowerCase() === 'imperial' ? 'imperial' : 'metric',
     };
+
+    const desiredFrontPct = desiredOverlap.front
+      ? parseFloat(desiredOverlap.front)
+      : 80;
+    const desiredSidePct = desiredOverlap.side
+      ? parseFloat(desiredOverlap.side)
+      : 80;
 
     const required = [
       params.sensorWidth,
@@ -38,18 +45,109 @@ router.get('/', (req, res) => {
       params.flightAltitude,
     ];
 
-    if (required.some((v) => isNaN(v) || v <= 0)) {
+    if (required.some((v) => !Number.isFinite(v) || v <= 0)) {
       return res.status(400).json({ error: 'Missing or invalid parameters' });
+    }
+
+    if (!Number.isFinite(params.roofHeight) || params.roofHeight < 0) {
+      return res.status(400).json({ error: 'Invalid roof height' });
+    }
+
+    if (
+      !Number.isFinite(desiredFrontPct) ||
+      !Number.isFinite(desiredSidePct) ||
+      desiredFrontPct < 0 ||
+      desiredSidePct < 0
+    ) {
+      return res.status(400).json({ error: 'Invalid desired overlap' });
     }
 
     if (params.roofHeight >= params.flightAltitude) {
       return res
         .status(400)
-        .json({ error: 'Roof height must be less than flight altitude' });
+        .json({ error: 'roofHeight must be < flightAltitude' });
     }
 
-    const result = calculateGsdMetrics({ ...params, thresholds: overlapThresholds });
-    res.json({ ...result, units: params.units });
+    const desiredFront = desiredFrontPct / 100;
+    const desiredSide = desiredSidePct / 100;
+
+    const isImperial = params.units === 'imperial';
+    const toMeters = (v) => (isImperial ? v * 0.3048 : v);
+    const fromMeters = (v) => (isImperial ? v * 3.28084 : v);
+    const convertGsd = (v) => (isImperial ? v / 2.54 : v);
+
+    const altitudeMeters = toMeters(params.flightAltitude);
+    const roofMeters = toMeters(params.roofHeight);
+
+    const groundGsdCm = calculateGSD({
+      sensorWidth: params.sensorWidth,
+      imageWidth: params.imageWidth,
+      altitude: altitudeMeters,
+      focalLength: params.focalLength,
+    });
+
+    const roofGsdCm = calculateGSD({
+      sensorWidth: params.sensorWidth,
+      imageWidth: params.imageWidth,
+      altitude: Math.max(1e-6, altitudeMeters - roofMeters),
+      focalLength: params.focalLength,
+    });
+
+    const footprintWidthMeters = (groundGsdCm * params.imageWidth) / 100;
+    const footprintHeightMeters = (groundGsdCm * params.imageHeight) / 100;
+
+    const { actualFront, actualSide } = computeActualOverlap({
+      flightAltitude: params.flightAltitude,
+      roofHeight: params.roofHeight,
+      desiredFront,
+      desiredSide,
+    });
+
+    const { altitudeOption, overlapOption } = recommendFixes({
+      flightAltitude: params.flightAltitude,
+      roofHeight: params.roofHeight,
+      desiredFront,
+      desiredSide,
+      actualFront,
+      actualSide,
+    });
+
+    const response = {
+      groundGSD: parseFloat(convertGsd(groundGsdCm).toFixed(3)),
+      roofGSD: parseFloat(convertGsd(roofGsdCm).toFixed(3)),
+      footprintWidth: parseFloat(fromMeters(footprintWidthMeters).toFixed(3)),
+      footprintHeight: parseFloat(fromMeters(footprintHeightMeters).toFixed(3)),
+      gsdUnit: isImperial ? 'in/pixel' : 'cm/pixel',
+      footprintUnit: isImperial ? 'feet' : 'meters',
+      overlap: {
+        desired: {
+          front: Math.round(desiredFront * 100),
+          side: Math.round(desiredSide * 100),
+        },
+        actual: {
+          front: Math.round(actualFront * 100),
+          side: Math.round(actualSide * 100),
+        },
+        recommendation: {
+          altitudeOption: {
+            flightAltitude: parseFloat(
+              altitudeOption.flightAltitude.toFixed(2),
+            ),
+            units: isImperial ? 'ft' : 'm',
+            note: altitudeOption.note,
+          },
+          overlapOption: {
+            front: Math.round(overlapOption.front * 100),
+            side: Math.round(overlapOption.side * 100),
+            units: '%',
+            note: overlapOption.note,
+          },
+        },
+      },
+      units: params.units,
+    };
+
+    res.json(response);
   } catch (err) {
     res.status(400).json({ error: err.message });
   }

--- a/server/utils/calculations.js
+++ b/server/utils/calculations.js
@@ -4,3 +4,65 @@ export function calculateGSD({ sensorWidth, imageWidth, altitude, focalLength })
   }
   return (sensorWidth * altitude) / (focalLength * imageWidth) * 100;
 }
+
+export function computeActualOverlap({
+  flightAltitude,
+  roofHeight = 0,
+  desiredFront,
+  desiredSide,
+}) {
+  const adjustedAltitude = Math.max(1e-6, flightAltitude - roofHeight);
+  const scale = adjustedAltitude / flightAltitude;
+  const clamp = (v) => Math.min(0.99, Math.max(0, v));
+  const actualFront = clamp(1 - (1 - desiredFront) / scale);
+  const actualSide = clamp(1 - (1 - desiredSide) / scale);
+  return { actualFront, actualSide };
+}
+
+export function recommendFixes({
+  flightAltitude,
+  roofHeight,
+  desiredFront,
+  desiredSide,
+  actualFront,
+  actualSide,
+}) {
+  const adjustedAltitude = Math.max(1e-6, flightAltitude - roofHeight);
+  const frontRatio = desiredFront / Math.max(actualFront, 1e-6);
+  const sideRatio = desiredSide / Math.max(actualSide, 1e-6);
+  const scaleNeeded = Math.max(frontRatio, sideRatio, 1);
+  let adjustedAltitudeNeeded = Math.min(
+    flightAltitude,
+    adjustedAltitude * scaleNeeded,
+  );
+  let recommendedFlightAltitude = roofHeight + adjustedAltitudeNeeded;
+  recommendedFlightAltitude = Math.max(recommendedFlightAltitude, roofHeight + 1e-6);
+
+  const buffer = 0.05;
+  let recommendedFront = Math.max(desiredFront, Math.min(0.99, actualFront));
+  let recommendedSide = Math.max(desiredSide, Math.min(0.99, actualSide));
+  if (actualFront < desiredFront) {
+    recommendedFront = Math.min(0.95, desiredFront + buffer);
+  }
+  if (actualSide < desiredSide) {
+    recommendedSide = Math.min(0.95, desiredSide + buffer);
+  }
+
+  const altitudeNote =
+    recommendedFlightAltitude > flightAltitude
+      ? `Raise altitude to restore ${Math.round(desiredFront * 100)}/${Math.round(
+          desiredSide * 100,
+        )} at roof.`
+      : 'Current altitude sufficient.';
+
+  const overlapNote = 'Keep altitude; increase overlaps.';
+
+  return {
+    altitudeOption: { flightAltitude: recommendedFlightAltitude, note: altitudeNote },
+    overlapOption: {
+      front: recommendedFront,
+      side: recommendedSide,
+      note: overlapNote,
+    },
+  };
+}

--- a/server/utils/gsdExamples.js
+++ b/server/utils/gsdExamples.js
@@ -1,27 +1,30 @@
-import { calculateGsdMetrics } from './gsdCalculator.js';
+import { computeActualOverlap, recommendFixes } from './calculations.js';
 
-// Common parameters for a hypothetical camera
-const common = {
-  sensorWidth: 13.2,
-  focalLength: 8.8,
-  imageWidth: 4000,
-  imageHeight: 3000,
+const desired = { front: 0.8, side: 0.8 };
+
+// Metric example
+const metricActual = computeActualOverlap({
   flightAltitude: 100,
-  frontOverlap: 0.8,
-  sideOverlap: 0.8,
-};
+  roofHeight: 20,
+  desiredFront: desired.front,
+  desiredSide: desired.side,
+});
+const metricFixes = recommendFixes({
+  flightAltitude: 100,
+  roofHeight: 20,
+  desiredFront: desired.front,
+  desiredSide: desired.side,
+  actualFront: metricActual.actualFront,
+  actualSide: metricActual.actualSide,
+});
+console.log('Metric 80/80 -> actual overlap', metricActual);
+console.log('Metric recommendations', metricFixes);
 
-console.log('Metric no roof:', calculateGsdMetrics(common));
-console.log(
-  'Metric roof 20m:',
-  calculateGsdMetrics({ ...common, roofHeight: 20 })
-);
-console.log(
-  'Imperial roof 65.6ft:',
-  calculateGsdMetrics({
-    ...common,
-    flightAltitude: 328.084, // 100 m in feet
-    roofHeight: 65.617, // 20 m in feet
-    units: 'imperial',
-  })
-);
+// Imperial parity check
+const imperialActual = computeActualOverlap({
+  flightAltitude: 328.084, // 100 m in feet
+  roofHeight: 65.617, // 20 m in feet
+  desiredFront: desired.front,
+  desiredSide: desired.side,
+});
+console.log('Imperial 80/80 -> actual overlap', imperialActual);


### PR DESCRIPTION
## Summary
- compute actual overlap at roof height and suggest fixes
- expose desired/actual overlap and recommendations from /api/gsd
- add example script illustrating metric/imperial parity

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `node utils/gsdExamples.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab1cc902b8832c871ced84c862ecb9