### PR TITLE
Add collapsible FAQ section

### DIFF
--- a/client/src/components/FAQ.jsx
+++ b/client/src/components/FAQ.jsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+
+const faqs = [
+  {
+    question: 'What is GSD?',
+    answer: (
+      <>
+        Ground Sample Distance (GSD) represents the real-world size of a pixel in an image. Smaller GSD means higher detail.{' '}
+        <a
+          href="https://en.wikipedia.org/wiki/Ground_sample_distance"
+          className="text-primary underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Learn more
+        </a>
+        .
+      </>
+    ),
+  },
+  {
+    question: 'Why does roof height affect GSD?',
+    answer:
+      'The effective altitude of your camera is flight altitude minus roof height. A lower distance to the subject results in a smaller GSD.',
+  },
+  {
+    question: 'How should I set my overlap values?',
+    answer: (
+      <>
+        For mapping, aim for at least 70% frontlap and 60% sidelap to ensure good coverage and 3D reconstruction.{' '}
+        <a
+          href="https://support.pix4d.com/hc/en-us/articles/202557349-What-is-overlap-and-how-much-is-required-"
+          className="text-primary underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Read guidelines
+        </a>
+        .
+      </>
+    ),
+  },
+];
+
+export default function FAQ() {
+  return (
+    <section className="max-w-2xl mx-auto mt-8" aria-labelledby="faq-heading">
+      <h2 id="faq-heading" className="text-xl font-semibold mb-4">
+        Frequently Asked Questions
+      </h2>
+      <div className="divide-y divide-gray-200 dark:divide-gray-700">
+        {faqs.map((faq, idx) => (
+          <FAQItem key={idx} faq={faq} idx={idx} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function FAQItem({ faq, idx }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div>
+      <button
+        className="w-full flex justify-between items-center py-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-controls={`faq-panel-${idx}`}
+        id={`faq-control-${idx}`}
+      >
+        <span className="font-medium">{faq.question}</span>
+        <svg
+          className={`w-5 h-5 transform transition-transform ${open ? 'rotate-180' : ''}`}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div
+        id={`faq-panel-${idx}`}
+        role="region"
+        aria-labelledby={`faq-control-${idx}`}
+        className={`px-4 pb-4 text-sm text-gray-700 dark:text-gray-300 transition-all duration-300 overflow-hidden ${
+          open ? 'max-h-96' : 'max-h-0'
+        }`}
+      >
+        <p>{faq.answer}</p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Calculator.jsx
+++ b/client/src/pages/Calculator.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { fetchGSD } from '../utils/api';
 import Results from '../components/Results';
 import { exportGsdPdf } from '../utils/pdf';
+import FAQ from '../components/FAQ';
 
 const DRONE_MODELS = {
   'DJI Phantom 4 Pro': {
@@ -114,11 +115,12 @@ export default function Calculator() {
         </div>
         <button className="px-4 py-2 bg-primary text-white rounded">Calculate</button>
       </form>
-        {loading && <p className="mt-4">Loading...</p>}
-        {error && <p className="mt-4 text-red-500">{error}</p>}
-        {result && !loading && !error && (
-          <Results result={result} onExportPdf={handleExportPdf} />
-        )}
+      {loading && <p className="mt-4">Loading...</p>}
+      {error && <p className="mt-4 text-red-500">{error}</p>}
+      {result && !loading && !error && (
+        <Results result={result} onExportPdf={handleExportPdf} />
+      )}
+      <FAQ />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add FAQ component with collapsible questions about GSD, roof height, and overlap guidance
- wire FAQ into calculator page for mobile-friendly access

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab2b125a98832c91286e8db7e7e1f8