### PR TITLE
feat: revamp UI layout and dev config

### DIFF
--- a/client/.env.development
+++ b/client/.env.development
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000

--- a/client/index.html
+++ b/client/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,18 +1,48 @@
-import React from 'react';
-import Sidebar from './components/Sidebar';
-import DarkModeToggle from './components/DarkModeToggle';
-import Calculator from './pages/Calculator';
+import React from "react";
+import Calculator from "./pages/Calculator";
+import "./styles/index.css";
 
 export default function App() {
   return (
-    <div className="min-h-screen flex">
-      <Sidebar />
-      <div className="flex-1 p-4">
-        <div className="flex justify-end mb-4">
-          <DarkModeToggle />
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 text-slate-800 dark:text-slate-100">
+      {/* Hero */}
+      <header className="bg-gradient-to-r from-blue-600 to-indigo-600 text-white shadow-sm">
+        <div className="mx-auto max-w-6xl px-4 py-6">
+          <h1 className="text-3xl md:text-4xl font-bold flex items-center gap-3">
+            <span>✈️</span> Drone Mapping GSD Calculator
+          </h1>
+          <p className="mt-2 opacity-90">
+            Professional tool for calculating ground sampling distance and coverage for drone mapping projects
+          </p>
         </div>
-        <Calculator />
+      </header>
+
+      {/* Toolbar */}
+      <div className="mx-auto max-w-6xl px-4 pt-4">
+        <div className="flex items-center gap-3 justify-between">
+          <button className="px-3 py-2 rounded-lg border border-slate-300/70 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800">
+            Help &amp; FAQ
+          </button>
+          <button
+            className="px-3 py-2 rounded-lg border border-slate-300/70 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800"
+            onClick={() => {
+              document.documentElement.classList.toggle("dark");
+              localStorage.theme = document.documentElement.classList.contains("dark") ? "dark" : "light";
+            }}
+          >
+            🌙 Dark Mode
+          </button>
+        </div>
       </div>
+
+      {/* Body */}
+      <main className="mx-auto max-w-6xl px-4 py-6">
+        <Calculator />
+      </main>
+
+      <footer className="mx-auto max-w-6xl px-4 pb-8 text-sm text-slate-500">
+        <p>Note: This calculation assumes flat terrain. Variations in elevation will affect actual GSD.</p>
+      </footer>
     </div>
   );
 }

--- a/client/src/pages/Calculator.jsx
+++ b/client/src/pages/Calculator.jsx
@@ -1,19 +1,20 @@
-import React, { useState } from 'react';
-import { fetchGSD } from '../utils/api';
-import Results from '../components/Results';
-import { exportGsdPdf } from '../utils/pdf';
-import FAQ from '../components/FAQ';
-import TokenGate from '../components/TokenGate';
-import { setToken } from '../utils/token';
+import React, { useState } from "react";
+import { fetchGSD } from "../utils/api";
+import { exportGsdPdf } from "../utils/pdf";
+import Results from "../components/Results";
+import AdvancedSettings from "../components/AdvancedSettings";
+import FAQ from "../components/FAQ";
+import TokenGate from "../components/TokenGate";
+import { setToken } from "../utils/token";
 
 const DRONE_MODELS = {
-  'DJI Phantom 4 Pro': {
+  "DJI Phantom 4 Pro": {
     sensorWidth: 13.2,
     imageWidth: 5472,
     imageHeight: 3648,
     focalLength: 8.8,
   },
-  'DJI Mavic 3': {
+  "DJI Mavic 3": {
     sensorWidth: 17.3,
     imageWidth: 5280,
     imageHeight: 3956,
@@ -22,13 +23,14 @@ const DRONE_MODELS = {
 };
 
 export default function Calculator() {
-  const [model, setModel] = useState('DJI Phantom 4 Pro');
+  const [model, setModel] = useState("DJI Phantom 4 Pro");
   const [altitude, setAltitude] = useState(100);
   const [roofHeight, setRoofHeight] = useState(0);
-  const [units, setUnits] = useState('metric');
+  const [units, setUnits] = useState("metric");
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [showFAQ, setShowFAQ] = useState(false);
 
   // token-gate state
   const [showTokenGate, setShowTokenGate] = useState(false);
@@ -50,12 +52,11 @@ export default function Calculator() {
       const data = await fetchGSD(params);
       setResult(data);
     } catch (err) {
-      // Show token modal only when backend returns 401 (Unauthorized)
-      if (err?.message?.toLowerCase().includes('unauthorized')) {
+      if (err?.message?.toLowerCase().includes("unauthorized")) {
         setPendingParams(params);
         setShowTokenGate(true);
       } else {
-        setError(err.message || 'Failed to fetch results');
+        setError(err.message || "Failed to fetch results");
         setResult(null);
       }
     } finally {
@@ -63,7 +64,6 @@ export default function Calculator() {
     }
   };
 
-  // When user enters a token, save it and retry the pending request
   const handleTokenSubmit = async (token) => {
     try {
       setToken(token);
@@ -75,20 +75,18 @@ export default function Calculator() {
         setPendingParams(null);
       }
     } catch (err) {
-      setError(err.message || 'Failed after token entry');
+      setError(err.message || "Failed after token entry");
     } finally {
       setLoading(false);
     }
   };
 
-  const unitLabel = units === 'imperial' ? 'ft' : 'm';
-
   const handleExportPdf = async () => {
     if (!result) {
-      alert('Please run a calculation first.');
+      alert("Please run a calculation first.");
       return;
     }
-    alert('Preparing PDF...');
+    alert("Preparing PDF...");
     const inputs = {
       model,
       altitude: parseFloat(altitude),
@@ -101,64 +99,141 @@ export default function Calculator() {
     alert(`Downloaded ${filename}`);
   };
 
+  const unitLabel = units === "imperial" ? "ft" : "m";
+
+  const modelSpecs = DRONE_MODELS[model];
+  const sensorHeight = (modelSpecs.sensorWidth * modelSpecs.imageHeight) / modelSpecs.imageWidth;
+
   return (
-    <div className="p-4">
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label className="block mb-1">Drone Model</label>
-          <select
-            value={model}
-            onChange={(e) => setModel(e.target.value)}
-            className="w-full p-2 border rounded dark:bg-gray-700"
-          >
-            {Object.keys(DRONE_MODELS).map((m) => (
-              <option key={m}>{m}</option>
-            ))}
-          </select>
-        </div>
+    <>
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left: inputs and results */}
+        <section className="lg:col-span-2 space-y-6">
+          {/* Card: Input Parameters */}
+          <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-sm">
+            <div className="px-5 py-4 border-b border-slate-100 dark:border-slate-800 flex items-center gap-2">
+              <span className="i-tabler-adjustments text-xl" />
+              <h2 className="font-semibold">Input Parameters</h2>
+            </div>
+            <div className="p-5">
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                  <label className="block mb-1">Drone Model</label>
+                  <select
+                    value={model}
+                    onChange={(e) => setModel(e.target.value)}
+                    className="w-full p-2 border rounded dark:bg-gray-700"
+                  >
+                    {Object.keys(DRONE_MODELS).map((m) => (
+                      <option key={m}>{m}</option>
+                    ))}
+                  </select>
+                </div>
 
-        <div>
-          <label className="block mb-1">Flight Altitude ({unitLabel})</label>
-          <input
-            type="number"
-            value={altitude}
-            onChange={(e) => setAltitude(e.target.value)}
-            className="w-full p-2 border rounded dark:bg-gray-700"
-          />
-        </div>
+                <div>
+                  <label className="block mb-1">Flight Altitude ({unitLabel})</label>
+                  <input
+                    type="number"
+                    value={altitude}
+                    onChange={(e) => setAltitude(e.target.value)}
+                    className="w-full p-2 border rounded dark:bg-gray-700"
+                  />
+                </div>
 
-        <div>
-          <label className="block mb-1">Roof Height ({unitLabel})</label>
-          <input
-            type="number"
-            value={roofHeight}
-            onChange={(e) => setRoofHeight(e.target.value)}
-            className="w-full p-2 border rounded dark:bg-gray-700"
-          />
-        </div>
+                <div>
+                  <label className="block mb-1">Roof Height ({unitLabel})</label>
+                  <input
+                    type="number"
+                    value={roofHeight}
+                    onChange={(e) => setRoofHeight(e.target.value)}
+                    className="w-full p-2 border rounded dark:bg-gray-700"
+                  />
+                </div>
 
-        <div>
-          <label className="block mb-1">Units</label>
-          <select
-            value={units}
-            onChange={(e) => setUnits(e.target.value)}
-            className="w-full p-2 border rounded dark:bg-gray-700"
-          >
-            <option value="metric">Metric</option>
-            <option value="imperial">Imperial</option>
-          </select>
-        </div>
+                <div>
+                  <label className="block mb-1">Units</label>
+                  <select
+                    value={units}
+                    onChange={(e) => setUnits(e.target.value)}
+                    className="w-full p-2 border rounded dark:bg-gray-700"
+                  >
+                    <option value="metric">Metric</option>
+                    <option value="imperial">Imperial</option>
+                  </select>
+                </div>
 
-        <button className="px-4 py-2 bg-primary text-white rounded">Calculate</button>
-      </form>
+                <div className="mt-6 flex items-center gap-3">
+                  <button
+                    type="submit"
+                    className="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700"
+                  >
+                    Calculate
+                  </button>
+                  <AdvancedSettings />
+                </div>
+              </form>
+            </div>
+          </div>
 
-      {loading && <p className="mt-4">Loading...</p>}
-      {error && <p className="mt-4 text-red-500">{error}</p>}
-      {result && !loading && !error && (
-        <Results result={result} onExportPdf={handleExportPdf} />
-      )}
+          {/* Card: Results */}
+          <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-sm">
+            <div className="px-5 py-4 border-b border-slate-100 dark:border-slate-800 flex items-center gap-2">
+              <span className="i-tabler-chart-infographic text-xl" />
+              <h2 className="font-semibold">Results</h2>
+            </div>
+            <div className="p-5 grid grid-cols-1 md:grid-cols-2 gap-5">
+              {loading && <p>Loading...</p>}
+              {error && <p className="text-red-500">{error}</p>}
+              {result && !loading && !error && <Results result={result} />}
+              <div className="rounded-xl bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-800 min-h-64 flex items-center justify-center">
+                <span className="text-slate-400">[Image Footprint Illustration]</span>
+              </div>
+            </div>
+            <div className="px-5 pb-5">
+              <button
+                className="px-3 py-2 rounded-lg border border-slate-300/70 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800"
+                onClick={handleExportPdf}
+              >
+                Export PDF
+              </button>
+            </div>
+          </div>
 
-      {/* Token prompt (only when backend rejects with 401) */}
+          {/* FAQ (collapsible) */}
+          <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-sm">
+            <div className="px-5 py-4 flex items-center justify-between">
+              <h2 className="font-semibold">Help &amp; FAQ</h2>
+              <button
+                className="text-sm px-3 py-1 rounded-lg border border-slate-300/70 dark:border-slate-700"
+                onClick={() => setShowFAQ((v) => !v)}
+              >
+                {showFAQ ? "Hide" : "Show"}
+              </button>
+            </div>
+            {showFAQ && (
+              <div className="px-5 pb-5">
+                <FAQ />
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* Right: camera specs panel */}
+        <aside className="space-y-6">
+          <div className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-sm sticky top-4">
+            <div className="px-5 py-4 border-b border-slate-100 dark:border-slate-800">
+              <h3 className="font-semibold">📷 Camera Specifications</h3>
+            </div>
+            <div className="p-5 space-y-3 text-sm">
+              <SpecRow label="Sensor Width" value={`${modelSpecs.sensorWidth} mm`} />
+              <SpecRow label="Sensor Height" value={`${sensorHeight.toFixed(1)} mm`} />
+              <SpecRow label="Focal Length" value={`${modelSpecs.focalLength} mm`} />
+              <SpecRow label="Resolution" value={`${modelSpecs.imageWidth} × ${modelSpecs.imageHeight} px`} />
+            </div>
+          </div>
+        </aside>
+      </div>
+
       {showTokenGate && (
         <TokenGate
           visible={showTokenGate}
@@ -166,9 +241,15 @@ export default function Calculator() {
           onClose={() => setShowTokenGate(false)}
         />
       )}
+    </>
+  );
+}
 
-      {/* Helpful docs for users */}
-      <FAQ />
+function SpecRow({ label, value }) {
+  return (
+    <div className="flex items-center justify-between border-b border-slate-100 dark:border-slate-800 pb-2">
+      <span className="text-slate-500">{label}</span>
+      <span className="font-medium">{value}</span>
     </div>
   );
 }

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -1,3 +1,5 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root { color-scheme: light dark; }

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 import javascriptObfuscator from 'vite-plugin-javascript-obfuscator';
 
 export default defineConfig(({ mode }) => ({
-  base: '/gsd-calculatorv1/', // repo name
+  base: mode === 'production' ? '/gsd-calculatorv1/' : '/',
   plugins: [
     react(),
     mode === 'production' &&


### PR DESCRIPTION
## Summary
- add hero header, dark-mode toggle, and toolbar for main app
- restructure calculator into card grid with camera specs sidebar and collapsible FAQ
- enable color-scheme reset, dev/prod base paths, and development API env variable

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find package 'vite-plugin-javascript-obfuscator')*


------
https://chatgpt.com/codex/tasks/task_e_68ab5703a4c0832c96aa35e640c589f9