### PR TITLE
Replace units dropdown with toggle

### DIFF
--- a/client/src/components/UnitToggle.jsx
+++ b/client/src/components/UnitToggle.jsx
@@ -1,25 +1,33 @@
-import React from 'react';
+import React from "react";
 
 export default function UnitToggle({ units, onChange }) {
   const toggle = (u) => () => onChange(u);
   return (
     <div className="flex flex-col gap-1">
-      <span className="text-sm font-medium text-gray-200">Units</span>
-      <div role="group" aria-label="Units" className="flex rounded overflow-hidden border border-gray-600 w-max">
+      <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Units</span>
+      <div
+        role="group"
+        aria-label="Units"
+        className="flex rounded overflow-hidden border border-gray-300 dark:border-gray-600 w-max"
+      >
         <button
           type="button"
-          onClick={toggle('metric')}
+          onClick={toggle("metric")}
           className={`px-3 py-1 text-sm ${
-            units === 'metric' ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-300'
+            units === "metric"
+              ? "bg-blue-600 text-white"
+              : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
           }`}
         >
           Metric
         </button>
         <button
           type="button"
-          onClick={toggle('imperial')}
+          onClick={toggle("imperial")}
           className={`px-3 py-1 text-sm ${
-            units === 'imperial' ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-300'
+            units === "imperial"
+              ? "bg-blue-600 text-white"
+              : "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300"
           }`}
         >
           Imperial

--- a/client/src/pages/Calculator.jsx
+++ b/client/src/pages/Calculator.jsx
@@ -6,6 +6,7 @@ import AdvancedSettings from "../components/AdvancedSettings";
 import FAQ from "../components/FAQ";
 import TokenGate from "../components/TokenGate";
 import { setToken } from "../utils/token";
+import UnitToggle from "../components/UnitToggle";
 
 const DRONE_MODELS = {
   "DJI Phantom 4 Pro": {
@@ -150,17 +151,7 @@ export default function Calculator() {
                   />
                 </div>
 
-                <div>
-                  <label className="block mb-1">Units</label>
-                  <select
-                    value={units}
-                    onChange={(e) => setUnits(e.target.value)}
-                    className="w-full p-2 border rounded dark:bg-gray-700"
-                  >
-                    <option value="metric">Metric</option>
-                    <option value="imperial">Imperial</option>
-                  </select>
-                </div>
+                <UnitToggle units={units} onChange={setUnits} />
 
                 <div className="mt-6 flex items-center gap-3">
                   <button


### PR DESCRIPTION
## Summary
- use UnitToggle component instead of select for metric/imperial units
- improve UnitToggle styling for light and dark themes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab68910b8c832caf7ded70f7a3fcc8