### PR TITLE
Fix API base URL handling and expose calcGsd

### DIFF
--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -1,21 +1,42 @@
 import { getToken } from './token';
 
-const apiBase =
-  import.meta.env.PROD && import.meta.env.VITE_API_URL
-    ? import.meta.env.VITE_API_URL
-    : '';
+// Always resolve the API base from the environment.  In development you should
+// set VITE_API_URL in .env.development to http://localhost:5000/api.  In production
+// you can leave VITE_API_URL undefined or set it to your API host; if undefined,
+// apiBase will be an empty string and calls will go to the same origin.
+const apiBase = import.meta.env.VITE_API_URL || '';
 
-export async function fetchGSD(params) {
+/**
+ * Perform a GSD calculation request.  Accepts a params object and returns
+ * the parsed JSON response.  If an API token is set in localStorage it will
+ * be sent as the x-api-token header.
+ *
+ * The backend exposes this endpoint as a GET at `${baseUrl}/api/gsd`.  If your
+ * apiBase already ends with `/api`, we append `gsd`; otherwise we prefix it
+ * with `/api/gsd`.
+ *
+ * @param {Object} params Query parameters such as sensorWidth, imageWidth, etc.
+ * @returns {Promise<Object>} Parsed JSON response from the server.
+ */
+export async function calcGsd(params) {
   const query = new URLSearchParams(params).toString();
   const headers = {};
   const token = getToken();
   if (token) {
     headers['x-api-token'] = token;
   }
-  const res = await fetch(`${apiBase}/api/gsd?${query}`, { headers });
+  // Determine the correct API path.  If apiBase already ends with `/api`,
+  // append the `gsd` route directly; otherwise, prefix it with `/api/gsd`.
+  const baseUrl = apiBase.endsWith('/api') ? apiBase : `${apiBase}/api`;
+  const res = await fetch(`${baseUrl}/gsd?${query}`, { headers });
   if (res.status === 401) {
     throw new Error('Unauthorized: missing or invalid API token');
   }
-  if (!res.ok) throw new Error('Network response was not ok');
+  if (!res.ok) {
+    throw new Error('Network response was not ok');
+  }
   return res.json();
 }
+
+// Backwards compatibility: still export fetchGSD for existing imports.
+export const fetchGSD = calcGsd;


### PR DESCRIPTION
## Summary
- resolve API base directly from VITE_API_URL and default to same-origin
- add new `calcGsd` utility and alias existing `fetchGSD`
- prevent duplicate `/api` segments in computed request path

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab6a733000832c92e285af1562deec